### PR TITLE
Call onClose() on BufDelete instead of BufLeave

### DIFF
--- a/denops/ghosttext/ghost.ts
+++ b/denops/ghosttext/ghost.ts
@@ -28,13 +28,9 @@ export const onClose = async (
     1,
   )[0]?.bufnr;
   if (bufnr == null) return;
-  await autocmd.remove(
-    denops,
-    ["BufLeave"],
-    "<buffer>",
-    { group: "dps-ghost" },
-  );
-  await helper.execute(denops, `bwipeout! ${bufnr}`);
+  if (await fn.bufexists(denops, bufnr)) {
+    await helper.execute(denops, `bwipeout! ${bufnr}`);
+  }
 };
 
 export const onOpen = async (
@@ -70,7 +66,7 @@ export const onOpen = async (
   });
   await autocmd.group(denops, "dps-ghost", (helper) => {
     helper.define(
-      ["BufLeave"],
+      ["BufDelete"],
       "<buffer>",
       `call denops#notify("${denops.name}", "close", [${bufnr}])`,
     );


### PR DESCRIPTION
This PR includes following changes.
- Don't close ghost text buffer on `BufLeave` because this event happens so frequently.
It's inconvenient that users cannot move around buffers to yank text and go to temporary buffers such as denite, telescope and so on.
- Don't remove autocmd on closing because the autocmd is automatically removed when the buffer is wiped out.
  Instead, I added `bufexists()` check to ensure that the buffer to be deleted exists.