### PR TITLE
Support `:GhostStart` before the denops server is ready

### DIFF
--- a/autoload/ghosttext.vim
+++ b/autoload/ghosttext.vim
@@ -1,5 +1,9 @@
 function ghosttext#start() abort
-  return denops#notify("ghosttext", "run", [])
+  call denops#plugin#wait_async("ghosttext", function("s:start"))
+endfunction
+
+function s:start() abort
+  call denops#notify("ghosttext", "run", [])
 endfunction
 
 function ghosttext#status() abort


### PR DESCRIPTION
Hi. Thank you for developing `dps-ghosttext.vim`.

I want to run `:GhostStart` right after Vim startup with `vim -c GhostStart`, but I get an error `E605: Exception not caught: The server is not ready yet`. This is because the denops server is not ready at this time.

This pull request solves this issue by using `denops#plugin#wait_async()`.